### PR TITLE
Change S3 pathing in archive-sync to point to the drud namespace

### DIFF
--- a/archive-sync.sh
+++ b/archive-sync.sh
@@ -8,8 +8,9 @@ else
   to="_default"
 fi
 
-S3ARGS="-k ${AWS_ACCESS_KEY} -sk ${AWS_SECRET_KEY}"
-LATEST=$(sudo s3latest $S3ARGS nmdarchive $sitename/$from)
+FOLDER="drud-"$sitename
+S3ARGS="-k ${AWS_ACCESS_KEY_ID} -sk ${AWS_SECRET_ACCESS_KEY}"
+LATEST=$(sudo s3latest $S3ARGS nmdarchive $FOLDER/$from)
 S3FROM="s3://nmdarchive/${LATEST}"
 S3TO=`echo $S3FROM | sed s/$from/$to/`
 STAGINGTO=`echo $S3FROM | sed s/$from/staging/`

--- a/archive-sync.sh
+++ b/archive-sync.sh
@@ -10,9 +10,9 @@ fi
 
 FOLDER="drud-"$sitename
 S3ARGS="-k ${AWS_ACCESS_KEY_ID} -sk ${AWS_SECRET_ACCESS_KEY}"
-LATEST=$(sudo s3latest $S3ARGS nmdarchive $FOLDER/$from)
+LATEST=$(s3latest $S3ARGS nmdarchive $FOLDER/$from)
 S3FROM="s3://nmdarchive/${LATEST}"
 S3TO=`echo $S3FROM | sed s/$from/$to/`
 STAGINGTO=`echo $S3FROM | sed s/$from/staging/`
-sudo s3copy $S3ARGS -n 8 -s 100 -f $S3FROM $S3TO
-sudo s3copy $S3ARGS -n 8 -s 100 -f $S3FROM $STAGINGTO
+s3copy $S3ARGS -n 8 -s 100 -f $S3FROM $S3TO
+s3copy $S3ARGS -n 8 -s 100 -f $S3FROM $STAGINGTO

--- a/jenkins-callback-wrapper.py
+++ b/jenkins-callback-wrapper.py
@@ -53,7 +53,7 @@ def trigger_web_jobs(environment, chef_action, bag_name):
     else:
         print "Looking for jobs that contain '{environment}'".format(environment=environment)
         for job_name in jenkins_job_list:
-            if job_name != "" and job_name != "{environment}-".format(environment=environment) and job_name.startswith(environment) and "drud" not in job_name:
+            if job_name != "" and job_name != "{environment}-".format(environment=environment) and job_name.startswith(environment):
                 print "Invoking {job_name}".format(job_name=job_name)
                 # Set build parameters, kick off a new build, and block until complete.
                 params = {'CHEF_ACTION': chef_action }


### PR DESCRIPTION
## The Problem
The archive-sync script is not pointed at the drud namespace.
Fixed a problem in the back-up script where ops-mass-action was excluding drud paths.

## The Fix
Added the drud folder path prepend. 
Also, normalized the S3 secret args for the new Jenkins.
Removed the drud job backup exclusion.

## The Test
Successful run: https://leroy.drud.com/job/archive-sync/6/console
And resultant files:
```
➜  aws-infra.jenkins-scripts git:(archive-drud-path) mc ls nmd/nmdarchive/drud-wordpresstest/
[2017-05-01 12:58:05 MDT]  18MiB _default-wordpresstest-1493662725.tar.gz
[2017-05-01 12:18:52 MDT]  18MiB production-wordpresstest-1493662725.tar.gz
[2017-05-01 12:58:06 MDT]  18MiB staging-wordpresstest-1493662725.tar.gz
```