### PR TITLE
Fixing the callback parameter for Jenkins mass action jobs

### DIFF
--- a/jenkins-callback-wrapper.py
+++ b/jenkins-callback-wrapper.py
@@ -39,7 +39,7 @@ def trigger_web_jobs(jenkins_url, environment, chef_action, bag_name):
             print "Job '{job_name}' could not be found in the jenkins job list. Available jobs are:\n\t{jobs}".format(job_name=job_name,jobs=",".join(jenkins_job_list))
             exit(1)
         # Set build parameters, kick off a new build, and block until complete.
-        params = {'CHEF_ACTION': chef_action }
+        params = {'action': chef_action }
         # Block so the jobs execute one-at-a-time
         try:
             print "Invoking job {job_name}...".format(job_name=job_name)
@@ -56,7 +56,7 @@ def trigger_web_jobs(jenkins_url, environment, chef_action, bag_name):
             if job_name != "" and job_name != "{environment}-".format(environment=environment) and job_name.startswith(environment):
                 print "Invoking {job_name}".format(job_name=job_name)
                 # Set build parameters, kick off a new build, and block until complete.
-                params = {'CHEF_ACTION': chef_action }
+                params = {'action': chef_action }
                 # Block so the jobs execute one-at-a-time
                 try:
                     J.build_job(job_name, params)

--- a/jenkins-callback-wrapper.py
+++ b/jenkins-callback-wrapper.py
@@ -9,17 +9,17 @@ import os
 import requests
 
 @click.command()
+@click.option('--jenkins-url', help="The URL of the Jenkins instance to connect to")
 @click.option('--environment', prompt='Environment', help='Environment e.g. production, staging')
 @click.option('--chef-action', prompt='Chef action', help='e.g. update, backup', type=click.Choice(['update', 'delete', 'backup']))
 @click.option('--bag-name', default=None, help="If set, will only trigger the job on the single bag specified")
-def trigger_web_jobs(environment, chef_action, bag_name):
+def trigger_web_jobs(jenkins_url, environment, chef_action, bag_name):
     """
     Trigger a mass web job based on environment
     :param environment - Which environment would you like to try executing this job on?
     :param chef_action - What would you like to perform on this environment?
     :param bag_name - Optional - what bag woud you specifically like to work on in this environment?
     """
-    jenkins_url = 'https://leroy.nmdev.us'
 
     print "Connecting to Jenkins..."
     try:


### PR DESCRIPTION
## The Problem
In the previous jenkins, we were using the `CHEF_ACTION` variable on each job. This variable is now `action`. This means that when the nightly back-up ran, it tried to pass a non-existant parameter and the job fell back to default behavior and ran updates on all the sites. This was not destructive, but it needed to be a backup.

## The Fix
Modified the `action` parameter to match the value on all of our Jenkins jobs.
