### PR TITLE
Add script for ghlabel

### DIFF
--- a/ghlabel-sync.sh
+++ b/ghlabel-sync.sh
@@ -1,10 +1,10 @@
 # Download binary from CircleCI build
-curl -o /bin/ghlabel https://42-99512752-gh.circle-artifacts.com/0/home/circleci/go/src/github.com/drud/ghlabel/bin/linux/ghlabel$CIRCLE_TOKEN
+curl -o ./ghlabel https://42-99512752-gh.circle-artifacts.com/0/home/circleci/go/src/github.com/drud/ghlabel/bin/linux/ghlabel$CIRCLE_TOKEN
 
 # Set permission to execute binary.
 # Execute binary using Drud as our organization and community as our reference repository.
 # (This is the actual sync)
-chmod +x ./bin/ghlabel && ./bin/ghlabel --org=drud --ref=community -r
+chmod +x ./ghlabel && ./ghlabel --org=drud --ref=community -r
 
 # Clean up
-rm ./bin/ghlabel -f
+rm -f ./ghlabel

--- a/ghlabel-sync.sh
+++ b/ghlabel-sync.sh
@@ -1,0 +1,10 @@
+# Download binary from CircleCI build
+curl -i https://circleci.com/api/v1.1/project/github/nmccrory/ghlabel/42/artifacts$CIRCLE_TOKEN | grep -o 'https://[^"]*' > artifacts.txt
+<artifacts.txt xargs -P4 -I % wget %$CIRCLE_TOKEN
+
+# TEMP: Print out a log of the filesystem
+ls -l
+
+# Set permission to execute binary
+# Step 2: Execute binary using Drud as our organization and community as our reference repository.
+chmod +x ./ghlabel$CIRCLE_TOKEN && ./ghlabel$CIRCLE_TOKEN --org=drud --ref=community -r

--- a/ghlabel-sync.sh
+++ b/ghlabel-sync.sh
@@ -1,10 +1,9 @@
 # Download binary from CircleCI build
-curl -i https://circleci.com/api/v1.1/project/github/nmccrory/ghlabel/42/artifacts$CIRCLE_TOKEN | grep -o 'https://[^"]*' > artifacts.txt
-<artifacts.txt xargs -P4 -I % wget %$CIRCLE_TOKEN
+curl -o ghlabel https://42-99512752-gh.circle-artifacts.com/0/home/circleci/go/src/github.com/drud/ghlabel/bin/linux/ghlabel$CIRCLE_TOKEN
 
 # TEMP: Print out a log of the filesystem
 ls -l
 
 # Set permission to execute binary
 # Step 2: Execute binary using Drud as our organization and community as our reference repository.
-chmod +x ./ghlabel$CIRCLE_TOKEN && ./ghlabel$CIRCLE_TOKEN --org=drud --ref=community -r
+chmod +x ./ghlabel && ./ghlabel --org=drud --ref=community -r

--- a/ghlabel-sync.sh
+++ b/ghlabel-sync.sh
@@ -1,9 +1,10 @@
 # Download binary from CircleCI build
-curl -o ghlabel https://42-99512752-gh.circle-artifacts.com/0/home/circleci/go/src/github.com/drud/ghlabel/bin/linux/ghlabel$CIRCLE_TOKEN
+curl -o /bin/ghlabel https://42-99512752-gh.circle-artifacts.com/0/home/circleci/go/src/github.com/drud/ghlabel/bin/linux/ghlabel$CIRCLE_TOKEN
 
-# TEMP: Print out a log of the filesystem
-ls -l
+# Set permission to execute binary.
+# Execute binary using Drud as our organization and community as our reference repository.
+# (This is the actual sync)
+chmod +x ./bin/ghlabel && ./bin/ghlabel --org=drud --ref=community -r
 
-# Set permission to execute binary
-# Step 2: Execute binary using Drud as our organization and community as our reference repository.
-chmod +x ./ghlabel && ./ghlabel --org=drud --ref=community -r
+# Clean up
+rm ./bin/ghlabel -f


### PR DESCRIPTION
This is the basis of a script for our ghlabel-sync Jenkins job to execute.

Going forward: if the Circle artifact fails to download, we need to handle that. So far, the best way to handle this seems to be to `make` from within the Jenkins workspace.